### PR TITLE
Incorported further suggestions

### DIFF
--- a/openvpn-client-manage.py
+++ b/openvpn-client-manage.py
@@ -39,6 +39,10 @@ openvpn_conf_directory = '/etc/openvpn'
 working_dir = os.getcwd()
 ovpn_template = os.path.join(working_dir, 'templates/client.conf.j2')
 
+def run(args, **kwargs):
+    args = [str(a) for a in args]
+    print('+', ' '.join(args))
+    return subprocess.run(args, check=True, **kwargs)
 
 def file_from_template(template_file, output_file, vars_dict):
     '''
@@ -55,21 +59,21 @@ def source_CA_vars():
     '''
     'source' the CA vars file.
     this creates a bash subprocess, sources the file, outputs the new
-    environment, then writes it to os.environ, key by key.
+    environment, then writes it to a dictionary and returns it.
     TODO: proper error handling here on Popen() and communicate()
     '''
-
+    vars_dict = {}
     print("setting OS environment from vars file")
     os.chdir(ca_directory)
+
     command = ['bash', '-c', 'source ' + 'vars' + ' && env']
-
     proc = subprocess.Popen(command, stdout = subprocess.PIPE)
-
     for line in proc.stdout:
         (key, _, value) = line.decode('ascii').rstrip().partition("=")
-        os.environ[key] = value
-
+        vars_dict[key] = value
     proc.communicate()
+
+    return vars_dict
 
 
 def create_client_keys(client):
@@ -79,13 +83,11 @@ def create_client_keys(client):
     '''
 
     # source vars for interacting with CA
-    source_CA_vars()
-    # enter the CA directory
-    os.chdir(ca_directory)
+    ca_env = source_CA_vars()
 
     # run pkitool, create keys
     print('running pkitool in ' + ca_directory + ' to create client keys')
-    subprocess.call(['./pkitool', client])
+    run(['./pkitool', client], env=ca_env, cwd=ca_directory)
 
     ca_cert = os.path.join(ca_keys_directory, 'ca.crt')
     client_cert = os.path.join(ca_keys_directory, client + '.crt')
@@ -115,13 +117,15 @@ def revoke_client_keys(client):
     '''
 
     # source vars for interacting with CA
-    source_CA_vars()
-    # enter the CA directory
-    os.chdir(ca_directory)
+    ca_env = source_CA_vars()
 
     # revoke keys
     print('running revoke-full in ' + ca_directory + ' to revoke client keys')
-    subprocess.call(['./revoke-full', client])
+    try:
+        run(['./revoke-full', client], env=ca_env, cwd=ca_directory)
+    except subprocess.CalledProcessError as err:
+        if (err.returncode != 2):
+            raise err
 
     # copy crl file
     print('copying crl file')
@@ -130,7 +134,7 @@ def revoke_client_keys(client):
 
     # reload openvpn settings to pick up the changes
     print('restarting openvpn')
-    subprocess.call(['systemctl', 'restart', 'openvpn@server'])
+    run(['systemctl', 'restart', 'openvpn@server'])
 
 
 if __name__ == '__main__':
@@ -139,8 +143,10 @@ if __name__ == '__main__':
             'Create or revoke client keys, generating an .ovpn file if needed.')
 
     group = argument_parser.add_mutually_exclusive_group(required=True)
-    group.add_argument('-c', '--create', action='store_true', help='Create client keys.')
-    group.add_argument('-r', '--revoke', action='store_true', help='Revoke client keys.')
+    group.add_argument('-c', '--create', action='store_true',
+                        help='Create client keys.')
+    group.add_argument('-r', '--revoke', action='store_true',
+                        help='Revoke client keys.')
 
     argument_parser.add_argument('client', help='The name for the client.')
     args = argument_parser.parse_args()

--- a/openvpn-setup.py
+++ b/openvpn-setup.py
@@ -130,6 +130,12 @@ if __name__ == '__main__':
     for keyfile in keyfiles:
         shutil.copy2(keyfile, conf_output_dir)
 
+    print('initializing revocation list')
+    subprocess.call(['./pkitool', 'CRL_INIT'])
+    subprocess.call(['./revoke-full', 'CRL_INIT'])
+    revocation_list = os.path.join(ca_keys_dir, 'crl.pem')
+    shutil.copy2(revocation_list, conf_output_dir)
+
     print('turning on ip forwarding')
     with open("/proc/sys/net/ipv4/ip_forward", 'w') as ipfwd:
         ipfwd.write("1")

--- a/templates/server.conf.j2
+++ b/templates/server.conf.j2
@@ -322,3 +322,6 @@ verb 3
 # sequential messages of the same message
 # category will be output to the log.
 ;mute 20
+
+# verify that a user's certificate is valid (has not been revoked)
+crl-verify /etc/openvpn/crl.pem


### PR DESCRIPTION
@mgax I incorporated some more of your suggestions and also finished up with revoking of certificates. everything is tested and working.

If you want you can merge this in too.

My questions still stand from the previous pull request:

1 - do you want all the extraneous comments in the config file templates or should i remove them so it's just the config options we need.

2 - how do we want to handle the linux-required options in the client config?

```
# NOTE: These should be uncommented for Linux clients
# script-security 2
# up /etc/openvpn/update-resolv-conf
# down /etc/openvpn/update-resolv-conf
```